### PR TITLE
update: `deno add` message on main page

### DIFF
--- a/islands/PMSelect.tsx
+++ b/islands/PMSelect.tsx
@@ -125,7 +125,7 @@ export default function PMSelect(
       </nav>
       <div>
         <div id="pm-deno-content" class="my-4">
-          <CopyText text={`deno add ${pkg}`} />
+          <CopyText text={`deno add jsr:${pkg}`} />
         </div>
         <div id="pm-npm-content" class="my-4">
           <CopyText text={`npx jsr add ${pkg}`} />


### PR DESCRIPTION
Closes: https://github.com/oakserver/oak/issues/688

The `deno add` message on the main page is missing the JSR specifier required some versions back. This pull request simply adds that.
![image](https://github.com/user-attachments/assets/b0843319-67e5-4ccb-9017-25fc9e156eef)

